### PR TITLE
Add `shape_by_conn`, `copy_shape`, and `setup_partials` support

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -50,8 +50,9 @@ jobs:
         run: |
           using Pkg
           Pkg.activate("./julia/OpenMDAO.jl")
-          using CondaPkg
           Pkg.develop("./julia/OpenMDAOCore.jl")
+          Pkg.instantiate()
+          using CondaPkg
           CondaPkg.add_pip("omjlcomps"; version="@./../../python")
           Pkg.update()
           Pkg.test()

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -49,7 +49,10 @@ jobs:
         shell: julia --color=yes {0}
         run: |
           using Pkg
+          using CondaPkg
           Pkg.activate("./julia/OpenMDAO.jl")
+          Pkg.develop("./julia/OpenMDAOCore.jl")
+          CondaPkg.add_pip("omjlcomps"; version="@./../../python")
           Pkg.update()
           Pkg.test()
         env:
@@ -90,7 +93,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ./python
-          python -c "import juliapkg; juliapkg.resolve()"
+          python -c "import juliapkg; juliapkg.add('OpenMDAOCore', '24d19c10-6eee-420f-95df-4537264b2753', dev=True, path='./julia/OpenMDAOCore.jl'); juliapkg.resolve()"
         env:
               JULIA_PKG_USE_CLI_GIT: 'true'
       - name: omjlcomps tests

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -50,8 +50,8 @@ jobs:
         run: |
           using Pkg
           Pkg.activate("./julia/OpenMDAO.jl")
-          Pkg.develop("./julia/OpenMDAOCore.jl")
           Pkg.instantiate()
+          Pkg.develop(path="./julia/OpenMDAOCore.jl")
           using CondaPkg
           CondaPkg.add_pip("omjlcomps"; version="@./../../python")
           Pkg.update()

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -49,8 +49,8 @@ jobs:
         shell: julia --color=yes {0}
         run: |
           using Pkg
-          using CondaPkg
           Pkg.activate("./julia/OpenMDAO.jl")
+          using CondaPkg
           Pkg.develop("./julia/OpenMDAOCore.jl")
           CondaPkg.add_pip("omjlcomps"; version="@./../../python")
           Pkg.update()
@@ -91,9 +91,10 @@ jobs:
               JULIA_PKG_USE_CLI_GIT: 'true'
       - name: omjlcomps install
         run: |
+          echo "PWD = $PWD"
           python -m pip install --upgrade pip
           pip install -e ./python
-          python -c "import juliapkg; juliapkg.add('OpenMDAOCore', '24d19c10-6eee-420f-95df-4537264b2753', dev=True, path='./julia/OpenMDAOCore.jl'); juliapkg.resolve()"
+          python -c "import juliapkg; juliapkg.add('OpenMDAOCore', '24d19c10-6eee-420f-95df-4537264b2753', dev=True, path='$PWD/julia/OpenMDAOCore.jl'); juliapkg.resolve()"
         env:
               JULIA_PKG_USE_CLI_GIT: 'true'
       - name: omjlcomps tests

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,6 +33,9 @@ jobs:
           Pkg.develop(PackageSpec(path="./julia/OpenMDAOCore.jl"))
           Pkg.develop(PackageSpec(path="./julia/OpenMDAO.jl"))
           Pkg.instantiate()
+          using CondaPkg
+          CondaPkg.add_pip("omjlcomps"; version="@./../python")
+          Pkg.update()
 
       - name: Build and deploy
         env:

--- a/julia/OpenMDAOCore.jl/src/OpenMDAOCore.jl
+++ b/julia/OpenMDAOCore.jl/src/OpenMDAOCore.jl
@@ -3,6 +3,7 @@ module OpenMDAOCore
 include("utils.jl")
 
 export VarData, PartialsData, AbstractExplicitComp, AbstractImplicitComp
+export has_setup_partials
 export has_compute_partials, has_compute_jacvec_product
 export has_apply_nonlinear, has_solve_nonlinear, has_linearize, has_apply_linear, has_solve_linear, has_guess_nonlinear 
 
@@ -25,6 +26,11 @@ end
 
 function setup(self::AbstractComp)
     throw(OpenMDAOMethodError(self, "setup"))
+    return nothing
+end
+
+function setup_partials(self::AbstractComp, input_sizes, output_sizes)
+    throw(OpenMDAOMethodError(self, "setup_partials"))
     return nothing
 end
 
@@ -71,6 +77,17 @@ end
 function guess_nonlinear!(self::AbstractImplicitComp, inputs, outputs, residuals)
     throw(OpenMDAOMethodError(self, "guess_nonlinear!"))
     return nothing
+end
+
+function has_setup_partials(self::AbstractComp)
+    # First, figure out which method would be called with self.
+    T = typeof(self)
+    specific = which(setup_partials, (T, Any, Any))
+    # Next, get the fallback method.
+    fallback = which(setup_partials, (AbstractComp, Any, Any))
+    # If the specific method isn't the fallback method, then the user must have
+    # implemented it, so return true.
+    return !(specific === fallback)
 end
 
 function has_compute_partials(self::AbstractExplicitComp)
@@ -175,13 +192,13 @@ Create a VarData object for an OpenMDAO variable named `name`.
 Specifically, if a `VarData` object `var` refers to an input variable, the `Component.add_input` call will look like this:
 
 ```python
-Component.add_input(var.name, shape=var.shape, val=var.val, units=var.units, tags=var.tags)
+Component.add_input(var.name, shape=var.shape, val=var.val, units=var.units, tags=var.tags, shape_by_conn=var.shape_by_conn)
 ```
 
 and if the `VarData` object `var` is an output variable, the `Component.add_output` call will look like this:
 
 ```python
-Component.add_output(var.name, shape=var.shape, val=var.val, units=var.units, lower=var.lower, upper=var.upper, tags=var.tags)
+Component.add_output(var.name, shape=var.shape, val=var.val, units=var.units, lower=var.lower, upper=var.upper, tags=var.tags, shape_by_conn=var.shape_by_conn)
 ```
 
 The `name` positional argument is required and sets the `name` field.
@@ -194,8 +211,10 @@ The value of the other `VarData` fields (e.g., `var.shape`, `var.val`, etc.) are
 - `lower::Union{Float64,<:AbstractArray{Float64,N},Nothing} = nothing`: variable's lower limit.
 - `upper::Union{Float64,<:AbstractArray{Float64,N},Nothing} = nothing`: variable's upper limit.
 - `tags::Union{<:AbstractVector{String},Nothing} = nothing`: variable tags.
+- `shape_by_conn::Bool = false`: if `true`, shape this variable by its connected output (if an input) or input (if an output)
+- `copy_shape::Union{String,Nothing} = nothing`: if a string, shape this variable by the local variable indicated by `copy_shape`
 """
-struct VarData{N,TVal<:Union{Float64,<:AbstractArray{Float64,N}},TUnits<:Union{String,Nothing},TBounds<:Union{Float64,<:AbstractArray{Float64,N}, Nothing}, TTags<:Union{<:AbstractVector{String},Nothing}}
+struct VarData{N,TVal<:Union{Float64,<:AbstractArray{Float64,N}},TUnits<:Union{String,Nothing},TBounds<:Union{Float64,<:AbstractArray{Float64,N}, Nothing}, TTags<:Union{<:AbstractVector{String},Nothing},TCS<:Union{String,Nothing}}
     name::String
     val::TVal
     shape::NTuple{N,Int64}
@@ -203,29 +222,31 @@ struct VarData{N,TVal<:Union{Float64,<:AbstractArray{Float64,N}},TUnits<:Union{S
     lower::TBounds
     upper::TBounds
     tags::TTags
+    shape_by_conn::Bool
+    copy_shape::TCS
 
-    function VarData(name, val::TVal, shape::NTuple{N,Int64}, units, lower::TBounds, upper::TBounds, tags::TTags=nothing) where {N,TVal<:Union{Float64,<:AbstractArray{Float64,N}},TBounds,TTags}
+    function VarData(name, val::TVal, shape::NTuple{N,Int64}, units, lower::TBounds, upper::TBounds, tags::TTags=nothing, shape_by_conn=false, copy_shape::TCS=nothing) where {N,TVal<:Union{Float64,<:AbstractArray{Float64,N}},TBounds,TTags,TCS}
         _vd_checkbounds(val, shape) || throw(ArgumentError("size of val argument $(size(val)) should match shape argument $(shape)"))
         _vd_checkbounds(lower, shape) || throw(ArgumentError("size of lower argument $(size(lower)) should match shape argument $(shape)"))
         _vd_checkbounds(upper, shape) || throw(ArgumentError("size of upper argument $(size(upper)) should match shape argument $(shape)"))
-        return new{N,typeof(val),typeof(units),TBounds,TTags}(name, val, shape, units, lower, upper, tags)
+        return new{N,typeof(val),typeof(units),TBounds,TTags,TCS}(name, val, shape, units, lower, upper, tags, shape_by_conn, copy_shape)
     end
 end
 
-VarData(name; val=nothing, shape=nothing, units=nothing, lower=nothing, upper=nothing, tags=nothing) = VarData(name, val, shape, units, lower, upper, tags)
+VarData(name; val=nothing, shape=nothing, units=nothing, lower=nothing, upper=nothing, tags=nothing, shape_by_conn=false, copy_shape=nothing) = VarData(name, val, shape, units, lower, upper, tags, shape_by_conn, copy_shape)
 
-VarData(name, val::Float64, shape::Nothing, units, lower, upper, tags=nothing) = VarData(name, val, (1,), units, lower, upper, tags)
-VarData(name, val::AbstractArray{Float64,N}, shape::Nothing, units, lower, upper, tags=nothing) where {N} = VarData(name, val, size(val), units, lower, upper, tags)
-VarData(name, val::Nothing, shape::Nothing, units, lower, upper, tags=nothing) = VarData(name, 1.0, (1,), units, lower, upper, tags)
+VarData(name, val::Float64, shape::Nothing, units, lower, upper, tags=nothing, shape_by_conn=false, copy_shape=nothing) = VarData(name, val, (1,), units, lower, upper, tags, shape_by_conn, copy_shape)
+VarData(name, val::AbstractArray{Float64,N}, shape::Nothing, units, lower, upper, tags=nothing, shape_by_conn=false, copy_shape=nothing) where {N} = VarData(name, val, size(val), units, lower, upper, tags, shape_by_conn, copy_shape)
+VarData(name, val::Nothing, shape::Nothing, units, lower, upper, tags=nothing, shape_by_conn=false, copy_shape=nothing) = VarData(name, 1.0, (1,), units, lower, upper, tags, shape_by_conn, copy_shape)
 
-VarData(name, val::Float64, shape::Int64, units, lower, upper, tags=nothing) = VarData(name, val, (shape,), units, lower, upper, tags)
-VarData(name, val::AbstractArray{Float64,N}, shape::Int64, units, lower, upper, tags=nothing) where {N} = VarData(name, val, (shape,), units, lower, upper, tags)
-VarData(name, val::Nothing, shape::Int64, units, lower, upper, tags=nothing) = VarData(name, 1.0, (shape,), units, lower, upper, tags)
+VarData(name, val::Float64, shape::Int64, units, lower, upper, tags=nothing, shape_by_conn=false, copy_shape=nothing) = VarData(name, val, (shape,), units, lower, upper, tags, shape_by_conn, copy_shape)
+VarData(name, val::AbstractArray{Float64,N}, shape::Int64, units, lower, upper, tags=nothing, shape_by_conn=false, copy_shape=nothing) where {N} = VarData(name, val, (shape,), units, lower, upper, tags, shape_by_conn, copy_shape)
+VarData(name, val::Nothing, shape::Int64, units, lower, upper, tags=nothing, shape_by_conn=false, copy_shape=nothing) = VarData(name, 1.0, (shape,), units, lower, upper, tags, shape_by_conn, copy_shape)
 
 # These next two are commented out because they're handled by the `VarData` inner constructor.
 # VarData(name, val::Float64, shape::NTuple{N,Int64}, units, lower, upper) where {N} = VarData(name, val, shape, units, lower, upper)
 # VarData(name, val::AbstractArray{Float64,N}, shape::NTuple{N,Int64}, units, lower, upper) where {N} = VarData(name, val, shape, units, lower, upper)
-VarData(name, val::Nothing, shape::NTuple{N,Int64}, units, lower, upper, tags=nothing) where {N} = VarData(name, 1.0, shape, units, lower, upper, tags)
+VarData(name, val::Nothing, shape::NTuple{N,Int64}, units, lower, upper, tags=nothing, shape_by_conn=false, copy_shape=nothing) where {N} = VarData(name, 1.0, shape, units, lower, upper, tags, shape_by_conn, copy_shape)
 
 _pd_rc_checkbounds(rows::Nothing, cols::Nothing) = true
 _pd_rc_checkbounds(rows::AbstractVector, cols::Nothing) = false

--- a/python/omjlcomps/__init__.py
+++ b/python/omjlcomps/__init__.py
@@ -15,10 +15,7 @@ def _initialize_common(self):
 
 def _setup_common(self):
     self._jlcomp = self.options['jlcomp']
-    # input_data, output_data, partials_data = jl.OpenMDAOCore.setup(self._jlcomp)
-    id_od_maybe_pd = jl.OpenMDAOCore.setup(self._jlcomp)
-    input_data = id_od_maybe_pd[0]
-    output_data = id_od_maybe_pd[1]
+    input_data, output_data, partials_data = jl.OpenMDAOCore.setup(self._jlcomp)
 
     for var in input_data:
         if var.tags is not None:
@@ -47,17 +44,16 @@ def _setup_common(self):
                         shape_by_conn=var.shape_by_conn,
                         copy_shape=var.copy_shape)
 
-    if not jl.OpenMDAOCore.has_setup_partials(self._jlcomp):
-        partials_data = id_od_maybe_pd[2]
-        for data in partials_data:
-            self.declare_partials(data.of, data.wrt,
-                                  rows=data.rows, cols=data.cols,
-                                  val=data.val, method=data.method)
+    for data in partials_data:
+        self.declare_partials(data.of, data.wrt,
+                              rows=data.rows, cols=data.cols,
+                              val=data.val, method=data.method)
 
 
 def _setup_partials_common(self):
     if jl.OpenMDAOCore.has_setup_partials(self._jlcomp):
-        input_data, output_data = jl.OpenMDAOCore.setup(self._jlcomp)
+        # Ignore the partials data from `setup`, since we've already passed that to `declare_partials` in `_setup_common`.
+        input_data, output_data, _ = jl.OpenMDAOCore.setup(self._jlcomp)
 
         # Build up a dict mapping the input names to their size.
         input_sizes = juliacall.convert(jl.Dict, {vd.name: self._get_var_meta(vd.name, "size") for vd in input_data})

--- a/python/omjlcomps/__init__.py
+++ b/python/omjlcomps/__init__.py
@@ -15,29 +15,60 @@ def _initialize_common(self):
 
 def _setup_common(self):
     self._jlcomp = self.options['jlcomp']
-    input_data, output_data, partials_data = jl.OpenMDAOCore.setup(self._jlcomp)
+    # input_data, output_data, partials_data = jl.OpenMDAOCore.setup(self._jlcomp)
+    id_od_maybe_pd = jl.OpenMDAOCore.setup(self._jlcomp)
+    input_data = id_od_maybe_pd[0]
+    output_data = id_od_maybe_pd[1]
 
     for var in input_data:
         if var.tags is not None:
             tags = list(var.tags)
         else:
             tags = None
-        self.add_input(var.name, shape=var.shape, val=var.val,
-                       units=var.units, tags=tags)
+        if var.shape_by_conn or var.copy_shape:
+            shape = None
+        else:
+            shape = var.shape
+        self.add_input(var.name, shape=shape, val=var.val,
+                       units=var.units, tags=tags, shape_by_conn=var.shape_by_conn,
+                       copy_shape=var.copy_shape)
 
     for var in output_data:
         if var.tags is not None:
             tags = list(var.tags)
         else:
             tags = None
-        self.add_output(var.name, shape=var.shape, val=var.val,
-                        units=var.units, lower=var.lower, upper=var.upper, tags=tags)
+        if var.shape_by_conn or var.copy_shape:
+            shape = None
+        else:
+            shape = var.shape
+        self.add_output(var.name, shape=shape, val=var.val,
+                        units=var.units, lower=var.lower, upper=var.upper, tags=tags,
+                        shape_by_conn=var.shape_by_conn,
+                        copy_shape=var.copy_shape)
 
-    for data in partials_data:
-        self.declare_partials(data.of, data.wrt,
-                              rows=data.rows, cols=data.cols,
-                              val=data.val, method=data.method)
+    if not jl.OpenMDAOCore.has_setup_partials(self._jlcomp):
+        partials_data = id_od_maybe_pd[2]
+        for data in partials_data:
+            self.declare_partials(data.of, data.wrt,
+                                  rows=data.rows, cols=data.cols,
+                                  val=data.val, method=data.method)
 
+
+def _setup_partials_common(self):
+    if jl.OpenMDAOCore.has_setup_partials(self._jlcomp):
+        input_data, output_data = jl.OpenMDAOCore.setup(self._jlcomp)
+
+        # Build up a dict mapping the input names to their size.
+        input_sizes = juliacall.convert(jl.Dict, {vd.name: self._get_var_meta(vd.name, "size") for vd in input_data})
+        # Build up a dict mapping the output names to their size.
+        output_sizes = juliacall.convert(jl.Dict, {vd.name: self._get_var_meta(vd.name, "size") for vd in output_data})
+
+        partials_data = jl.OpenMDAOCore.setup_partials(self._jlcomp, input_sizes, output_sizes)
+        for data in partials_data:
+            self.declare_partials(data.of, data.wrt,
+                                  rows=data.rows, cols=data.cols,
+                                  val=data.val, method=data.method)
 
 class JuliaExplicitComp(om.ExplicitComponent):
     """
@@ -95,6 +126,10 @@ class JuliaExplicitComp(om.ExplicitComponent):
                         raise e from None
 
             self.compute_jacvec_product = MethodType(compute_jacvec_product, self)
+
+    def setup_partials(self):
+        _setup_partials_common(self)
+
 
     def compute(self, inputs, outputs):
         inputs_dict = juliacall.convert(jl.Dict, dict(inputs))
@@ -211,9 +246,10 @@ class JuliaImplicitComp(om.ImplicitComponent):
                     else:
                         raise e from None
 
-            # Hello Owen. Red Knights vs Greens.
             self.solve_linear = MethodType(solve_linear, self)
 
+    def setup_partials(self):
+        _setup_partials_common(self)
 
     def _configure(self):
         super()._configure()

--- a/python/omjlcomps/test/test_ecomp.jl
+++ b/python/omjlcomps/test/test_ecomp.jl
@@ -219,5 +219,35 @@ function OpenMDAOCore.compute_jacvec_product!(self::ECompMatrixFree, inputs, d_i
     return nothing
 end
 
+struct ECompShapeByConn <: OpenMDAOCore.AbstractExplicitComp end
+
+function OpenMDAOCore.setup(self::ECompShapeByConn)
+    input_data = [VarData("x"; shape_by_conn=true)]
+    output_data = [VarData("y"; shape_by_conn=true, copy_shape="x")]
+
+    return input_data, output_data
+end
+
+function OpenMDAOCore.setup_partials(self::ECompShapeByConn, input_shapes, output_shapes)
+    @assert input_shapes["x"] == output_shapes["y"]
+    n = only(input_shapes["x"])
+    partials_data = [PartialsData("y", "x"; rows=0:n-1, cols=0:n-1)]
+
+    return partials_data
+end
+
+function OpenMDAOCore.compute!(self::ECompShapeByConn, inputs, outputs)
+    x = inputs["x"]
+    y = outputs["y"]
+    y .= 2 .* x.^2 .+ 1
+    return nothing
+end
+
+function OpenMDAOCore.compute_partials!(self::ECompShapeByConn, inputs, partials)
+    x = inputs["x"]
+    dydx = partials["y", "x"]
+    dydx .= 4 .* x
+    return nothing
+end
 
 end # module

--- a/python/omjlcomps/test/test_ecomp.jl
+++ b/python/omjlcomps/test/test_ecomp.jl
@@ -224,13 +224,14 @@ struct ECompShapeByConn <: OpenMDAOCore.AbstractExplicitComp end
 function OpenMDAOCore.setup(self::ECompShapeByConn)
     input_data = [VarData("x"; shape_by_conn=true)]
     output_data = [VarData("y"; shape_by_conn=true, copy_shape="x")]
+    partials_data = []
 
-    return input_data, output_data
+    return input_data, output_data, partials_data
 end
 
-function OpenMDAOCore.setup_partials(self::ECompShapeByConn, input_shapes, output_shapes)
-    @assert input_shapes["x"] == output_shapes["y"]
-    n = only(input_shapes["x"])
+function OpenMDAOCore.setup_partials(self::ECompShapeByConn, input_sizes, output_sizes)
+    @assert input_sizes["x"] == output_sizes["y"]
+    n = only(input_sizes["x"])
     partials_data = [PartialsData("y", "x"; rows=0:n-1, cols=0:n-1)]
 
     return partials_data

--- a/python/omjlcomps/test/test_icomp.jl
+++ b/python/omjlcomps/test/test_icomp.jl
@@ -513,7 +513,8 @@ function OpenMDAOCore.setup(self::ImplicitShapeByConn)
         VarData("z1"; val=2.0, shape_by_conn=true, copy_shape="x"),
         VarData("z2"; val=3.0, shape_by_conn=true, copy_shape="x")]
 
-    return inputs, outputs
+    partials = []
+    return inputs, outputs, partials
 end
 
 function OpenMDAOCore.setup_partials(self::ImplicitShapeByConn, input_sizes, output_sizes)

--- a/python/omjlcomps/test/test_julia_implicit_comp.py
+++ b/python/omjlcomps/test/test_julia_implicit_comp.py
@@ -466,6 +466,82 @@ class TestGuessNonlinearImplicitComp(unittest.TestCase):
                                                    decimal=12)
 
 
+class TestShapeByConn(unittest.TestCase):
+
+    def setUp(self):
+        p = self.p = om.Problem()
+        n = self.n = 10
+        a = self.a = 3.0
+        comp = om.IndepVarComp()
+        comp.add_output("x", shape=n)
+        comp.add_output("y", shape=n)
+        p.model.add_subsystem("input_comp", comp, promotes_outputs=["x", "y"])
+        icomp = jl.ICompTest.ImplicitShapeByConn(a)
+        comp = JuliaImplicitComp(jlcomp=icomp)
+        comp.linear_solver = om.DirectSolver(assemble_jac=True)
+        comp.nonlinear_solver = om.NewtonSolver(solve_subsystems=True, iprint=2, err_on_non_converge=True)
+        p.model.add_subsystem("icomp", comp, promotes_inputs=["x", "y"], promotes_outputs=["z1", "z2"])
+        p.setup(force_alloc_complex=True)
+        p.set_val("x", 3.0)
+        p.set_val("y", 4.0)
+        p.run_model()
+
+    def test_results(self):
+        p = self.p
+        a = self.a
+        expected = a*p.get_val("x")**2 + p.get_val("y")**2
+        actual = p.get_val("z1")
+        np.testing.assert_almost_equal(actual, expected)
+        expected = a*p.get_val("x") + p.get_val("y")
+        actual = p.get_val("z2")
+        np.testing.assert_almost_equal(actual, expected)
+
+    def test_partials(self):
+        p = self.p
+        np.set_printoptions(linewidth=1024)
+        cpd = self.p.check_partials(compact_print=True, out_stream=None, method='cs')
+
+        # Check that the partials the user provided are correct.
+        icomp_partials = cpd["icomp"]
+
+        actual = icomp_partials["z1", "x"]['J_fwd']
+        expected = np.zeros((self.n, self.n))
+        expected[range(self.n), range(self.n)] = 2*self.a*p.get_val("x")
+        np.testing.assert_almost_equal(actual=actual, desired=expected, decimal=12)
+
+        actual = icomp_partials["z1", "y"]['J_fwd']
+        expected = np.zeros((self.n, self.n))
+        expected[range(self.n), range(self.n)] = 2*p.get_val("y")
+        np.testing.assert_almost_equal(actual=actual, desired=expected, decimal=12)
+
+        actual = icomp_partials["z1", "z1"]['J_fwd']
+        expected = np.zeros((self.n, self.n))
+        expected[range(self.n), range(self.n)] = -1.0
+        np.testing.assert_almost_equal(actual=actual, desired=expected, decimal=12)
+
+        actual = icomp_partials["z2", "x"]['J_fwd']
+        expected = np.zeros((self.n, self.n))
+        expected[range(self.n), range(self.n)] = self.a
+        np.testing.assert_almost_equal(actual=actual, desired=expected, decimal=12)
+
+        actual = icomp_partials["z2", "y"]['J_fwd']
+        expected = np.zeros((self.n, self.n))
+        expected[range(self.n), range(self.n)] = 1.0
+        np.testing.assert_almost_equal(actual=actual, desired=expected, decimal=12)
+
+        actual = icomp_partials["z2", "z2"]['J_fwd']
+        expected = np.zeros((self.n, self.n))
+        expected[range(self.n), range(self.n)] = -1.0
+        np.testing.assert_almost_equal(actual=actual, desired=expected, decimal=12)
+
+        # Check that partials approximated by the complex-step method match the user-provided partials.
+        for comp in cpd:
+            for (var, wrt) in cpd[comp]:
+                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
+                                               desired=cpd[comp][var, wrt]['J_fd'],
+                                               decimal=12)
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds the capability to dynamically size inputs and outputs a la https://openmdao.org/newdocs/versions/latest/features/experimental/dyn_shapes.html to OpenMDAO.jl.

It also slightly adjusts the CI and docs to use the local versions of omjlcomps and OpenMDAOCore.jl instead of whatever's found in the registry for tests that depend on those packages.