### PR TITLE
Make `omjlcomps` tests import `juliacall` first

### DIFF
--- a/python/omjlcomps/test/test_julia_implicit_comp.py
+++ b/python/omjlcomps/test/test_julia_implicit_comp.py
@@ -1,6 +1,7 @@
 """
 Unit tests for JuliaImplicitComp
 """
+import juliacall; jl = juliacall.newmodule("OpenMDAOJuliaImplicitCompTest")
 import os
 import time
 import unittest
@@ -9,9 +10,6 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-
-# from juliacall import Main as jl
-import juliacall; jl = juliacall.newmodule("OpenMDAOJuliaImplicitCompTest")
 
 from omjlcomps import JuliaImplicitComp
 


### PR DESCRIPTION
Workaround for https://github.com/cjdoris/PythonCall.jl/issues/255