### PR TITLE
Add `long_description` to `python/setup.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ OpenMDAO.jl consists of three pieces of software:
 
   * OpenMDAOCore.jl: A small, pure-Julia package that allows users to define Julia code that will eventually be used in an OpenMDAO `Problem`. OpenMDAOCore.jl defines two Julia abstract types (`AbstractExplicitComponent` and `AbstractImplicitComponent`) and methods that mimic OpenMDAO's ExplicitComponent and ImplicitComponent classes.
   * `omjlcomps`: A Python package (actually, a [OpenMDAO Plugin](https://openmdao.org/newdocs/versions/latest/features/experimental/plugins.html)) that defines two classes, `JuliaExplicitComp` and `JuliaImplicitComp`, which inherit from OpenMDAO's `ExplicitComponent` and `ImplicitComponent`, respectively.
-    These components takes instances of concrete subtypes of `OpenMDAOCore.ExplicitComponent` and `OpenMDAOCore.ImplicitComponent` and turn them into instances of `JuliaExplicitComp` and `JuliaImplicitComp`.
+    These components take instances of concrete subtypes of `OpenMDAOCore.ExplicitComponent` and `OpenMDAOCore.ImplicitComponent` and turn them into instances of `JuliaExplicitComp` and `JuliaImplicitComp`.
     Like any other OpenMDAO `ExplicitComponent` or `ImplicitComponent` objects, `JuliaExplicitComp` and `JuliaImplicitComp` instances can be used in an OpenMDAO model, but call Julia code in their methods (`compute`, `apply_nonlinear`, etc.).
   * OpenMDAO.jl: A Julia package that has the openmdao and `omjlcomps` Python packages as dependencies.
     Users can install `OpenMDAO.jl` and have the full power of the OpenMDAO framework at their disposal in Julia.

--- a/python/README.md
+++ b/python/README.md
@@ -1,2 +1,7 @@
-# OpenMDAO Julia Components
-omjlcomps
+# omjlcomps: OpenMDAO Julia Components
+
+`omjlcomps` is a small Python package (actually, a [OpenMDAO Plugin](https://openmdao.org/newdocs/versions/latest/features/experimental/plugins.html)) that defines two classes, `JuliaExplicitComp` and `JuliaImplicitComp`, which inherit from OpenMDAO's `ExplicitComponent` and `ImplicitComponent`, respectively.
+These components work with a Julia package called [OpenMDAOCore.jl](https://github.com/byuflowlab/OpenMDAO.jl) to create OpenMDAO `Components` that call Julia code.
+Specifically, `JuliaExplicitComp` and `JuliaImplicitComp` take instances of concrete subtypes of `OpenMDAOCore.ExplicitComponent` and `OpenMDAOCore.ImplicitComponent` and turn them into instances of `JuliaExplicitComp` and `JuliaImplicitComp`.
+Like any other OpenMDAO `ExplicitComponent` or `ImplicitComponent` objects, `JuliaExplicitComp` and `JuliaImplicitComp` instances can be used in an OpenMDAO model, but call Julia code in their methods (`compute`, `apply_nonlinear`, etc.).
+See the [OpenMDAO.jl docs](http://flow.byu.edu/OpenMDAO.jl/dev/) for more information and examples.

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,14 @@
-
 from setuptools import setup
 
-setup_args = {'description': 'Create OpenMDAO Components using the Julia programming language',
+from pathlib import Path
+from io import open
+
+with open(Path(__file__).parent / "README.md", encoding="utf-8") as f:
+    long_description = f.read()
+
+setup_args = {
+   'description': 'Create OpenMDAO Components using the Julia programming language',
+   'long_description': long_description,
    'entry_points': {
        'openmdao_component': [
            'juliaexplicitcomp=omjlcomps:JuliaExplicitComp',


### PR DESCRIPTION
I guess a `long_description` is required for registering to PyPI? At least for the way I'm doing it...