### PR TITLE
`omjlcomps` OpenMDAO version fix

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         julia-version:
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/julia/OpenMDAO.jl/test/runtests.jl
+++ b/julia/OpenMDAO.jl/test/runtests.jl
@@ -1045,6 +1045,7 @@ end
                 var = pyconvert(Any, pyvar)
                 wrt = pyconvert(Any, pywrt)
                 # In OpenMDAO 3.26.0, the correct key is always `"J_fwd"`, but in 3.30.0 it depends on the `mode` argument to `problem.setup()`.
+                J_actual = nothing
                 try
                     J_actual = pyconvert(Dict, ctd[var, wrt])["J_fwd"]
                 catch e1

--- a/python/omjlcomps/test/test_julia_implicit_comp.py
+++ b/python/omjlcomps/test/test_julia_implicit_comp.py
@@ -396,7 +396,15 @@ class TestSolveLinearImplicitComp(unittest.TestCase):
         for p in [self.p_fwd, self.p_rev]:
             ctd = p.check_totals(of=["z1", "z2"], wrt=["x", "y"], method='cs', compact_print=True, out_stream=None)
             for of_wrt in ctd:
-                np.testing.assert_almost_equal(actual=ctd[of_wrt]['J_fwd'],
+                # In OpenMDAO 3.26.0, the correct key is always `"J_fwd"`, but in 3.30.0 it depends on the `mode` argument to `problem.setup()`.
+                try:
+                    J_actual = ctd[of_wrt]["J_fwd"]
+                except KeyError:
+                    try:
+                        J_actual = ctd[of_wrt]["J_rev"]
+                    except KeyError:
+                        raise(ValueError(f"ctd[{of_wrt}] contains neither 'J_fwd' nor 'J_rev'.\nctd.keys() = {ctd.keys()}"))
+                np.testing.assert_almost_equal(actual=J_actual,
                                                desired=ctd[of_wrt]['J_fd'],
                                                decimal=12)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,7 +16,7 @@ setup_args = {
            'juliaimplicitcomp=omjlcomps:JuliaImplicitComp'
        ]
     },
-   'install_requires': ['openmdao~=3.26.0', 'juliapkg~=0.1.10', 'juliacall~=0.9.13'],
+   'install_requires': ['openmdao~=3.26', 'juliapkg~=0.1.10', 'juliacall~=0.9.13'],
    'keywords': ['openmdao_component'],
    'license': 'MIT',
    'name': 'omjlcomps',

--- a/python/setup.py
+++ b/python/setup.py
@@ -21,7 +21,7 @@ setup_args = {
    'license': 'MIT',
    'name': 'omjlcomps',
    'packages': ['omjlcomps', 'omjlcomps.test'],
-   'version': '0.2.3',
+   'version': '0.2.4',
    'include_package_data': True}
 
 setup(**setup_args)


### PR DESCRIPTION
`omjlcomps` use to require OpenMDAO version `~=3.26.0`, which is more restrictive than I thought (only allows versions starting with `3.26`). Changing to `~=3.26`, which allows versions starting with `3` and any minor versions `>=26`.